### PR TITLE
✨ [Feat/#17] EstimateCalculation 엔티티 생성 후 구조 리팩토링 및 계산/저장 책임 분리

### DIFF
--- a/src/main/java/com/zzimple/estimate/guest/entity/MoveItems.java
+++ b/src/main/java/com/zzimple/estimate/guest/entity/MoveItems.java
@@ -74,5 +74,5 @@ public class MoveItems extends BaseTimeEntity {
 
   private String specialNote;
 
-  private Integer item_totalPrice;
+  private Integer per_item_totalPrice;
 }

--- a/src/main/java/com/zzimple/estimate/owner/dto/response/CalculateOwnerInputResponse.java
+++ b/src/main/java/com/zzimple/estimate/owner/dto/response/CalculateOwnerInputResponse.java
@@ -1,0 +1,21 @@
+package com.zzimple.estimate.owner.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "사장님 - 최종 계산 결과 응답")
+public class CalculateOwnerInputResponse {
+  private int itemTotal;
+  private int truck_charge;
+  private int extraTotal;
+  private int finalTotal;
+}

--- a/src/main/java/com/zzimple/estimate/owner/entity/EstimateCalculation.java
+++ b/src/main/java/com/zzimple/estimate/owner/entity/EstimateCalculation.java
@@ -1,0 +1,39 @@
+package com.zzimple.estimate.owner.entity;
+
+import com.zzimple.global.common.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "estimate_calculation")
+public class EstimateCalculation extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private Long estimateNo;
+
+  private Long storeId;
+
+  private int truck_charge;
+
+  private int itemsTotalPrice;
+
+  private int extraChargesTotal;
+
+  private int finalTotalPrice;
+}

--- a/src/main/java/com/zzimple/estimate/owner/repository/EstimateCalculationRepository.java
+++ b/src/main/java/com/zzimple/estimate/owner/repository/EstimateCalculationRepository.java
@@ -1,0 +1,9 @@
+package com.zzimple.estimate.owner.repository;
+
+import com.zzimple.estimate.owner.entity.EstimateCalculation;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EstimateCalculationRepository extends JpaRepository<EstimateCalculation, Long> {
+  Optional<EstimateCalculation> findByEstimateNo(Long estimateNo);
+}

--- a/src/main/java/com/zzimple/estimate/owner/service/EstimateDetailUpdateService.java
+++ b/src/main/java/com/zzimple/estimate/owner/service/EstimateDetailUpdateService.java
@@ -6,9 +6,12 @@ import com.zzimple.estimate.guest.enums.EstimateStatus;
 import com.zzimple.estimate.guest.repository.MoveItemsRepository;
 import com.zzimple.estimate.owner.dto.request.SubmitFinalEstimateRequest;
 import com.zzimple.estimate.owner.dto.request.SaveEstimatePriceRequest.ExtraChargeRequest;
+import com.zzimple.estimate.owner.dto.response.CalculateOwnerInputResponse;
+import com.zzimple.estimate.owner.entity.EstimateCalculation;
 import com.zzimple.estimate.owner.entity.EstimateExtraCharge;
 import com.zzimple.estimate.owner.entity.StorePriceSetting;
 import com.zzimple.estimate.owner.exception.EstimateErrorCode;
+import com.zzimple.estimate.owner.repository.EstimateCalculationRepository;
 import com.zzimple.estimate.owner.repository.EstimateExtraChargeRepository;
 import com.zzimple.estimate.owner.repository.EstimateRepository;
 import com.zzimple.estimate.owner.repository.StorePriceSettingRepository;
@@ -32,6 +35,7 @@ public class EstimateDetailUpdateService {
   private final EstimateExtraChargeRepository estimateExtraChargeRepository;
   private final MoveItemsRepository moveItemsRepository;
   private final StoreRepository storeRepository;
+  private final EstimateCalculationRepository estimateCalculationRepository;
 
   @Transactional
   public void saveOwnerInput(Long storeId, Long estimateNo, SubmitFinalEstimateRequest request) {
@@ -42,66 +46,106 @@ public class EstimateDetailUpdateService {
     Store store = storeRepository.findById(storeId)
         .orElseThrow(() -> new EntityNotFoundException("Store not found with id=" + storeId));
 
-    StorePriceSetting setting = storePriceSettingRepository.findById(storeId)
-        .orElseThrow(() -> new CustomException(EstimateErrorCode.STORE_PRICE_SETTING_NOT_FOUND));
-
-    int totalExtraCharge = 0;
-
-    // 1. 트럭 개수 추가금
     Integer truckCount = request.getTruckCount();
-    if (truckCount != null && truckCount > 1) {
-      int truckExtra = (truckCount - 1) * setting.getPerTruckCharge();
-      totalExtraCharge += truckExtra;
 
+    if (truckCount != null) {
       estimate.setTruckCount(truckCount);
-
-      saveExtraCharge(estimateNo, storeId, "트럭 추가금 (" + truckCount + "대)", truckExtra);
     }
 
-    // 2. 직접 입력한 추가 사유
     List<ExtraChargeRequest> extraCharges = request.getExtraCharges();
     if (extraCharges != null) {
-      for (ExtraChargeRequest charge : extraCharges) {
-        totalExtraCharge += charge.getAmount();
-        saveExtraCharge(estimateNo,storeId, charge.getReason(), charge.getAmount());
+      for (ExtraChargeRequest ec : extraCharges) {
+        saveExtraCharge(estimateNo, storeId, ec.getReason(), ec.getAmount());
       }
     }
 
-    // 3. 날짜 조건에 따른 추가금
-    if (estimate.getIsHoliday()) {
-      totalExtraCharge += setting.getHolidayCharge();
-      saveExtraCharge(estimateNo, storeId,"공휴일 추가금", setting.getHolidayCharge());
+    // 2) 단가 설정 조회
+    StorePriceSetting setting = storePriceSettingRepository.findById(storeId)
+        .orElseThrow(() -> new CustomException(
+            EstimateErrorCode.STORE_PRICE_SETTING_NOT_FOUND));
+
+    // 4) 공휴일
+    if (Boolean.TRUE.equals(estimate.getIsHoliday())) {
+      saveExtraCharge(estimateNo, storeId,
+          "공휴일 추가금",
+          setting.getHolidayCharge());
     }
 
-    if (estimate.getIsGoodDay()) {
-      totalExtraCharge += setting.getGoodDayCharge();
-      saveExtraCharge(estimateNo, storeId,"손 없는 날 추가금", setting.getGoodDayCharge());
+    // 5) 손 없는 날
+    if (Boolean.TRUE.equals(estimate.getIsGoodDay())) {
+      saveExtraCharge(estimateNo, storeId,
+          "손 없는 날 추가금",
+          setting.getGoodDayCharge());
     }
 
-    if (estimate.getIsWeekend()) {
-      totalExtraCharge += setting.getWeekendCharge();
-      saveExtraCharge(estimateNo, storeId,"주말 추가금", setting.getWeekendCharge());
+    // 6) 주말
+    if (Boolean.TRUE.equals(estimate.getIsWeekend())) {
+      saveExtraCharge(estimateNo, storeId,
+          "주말 추가금",
+          setting.getWeekendCharge());
     }
-
-    //   1. moveItems 직접 조회 (기존 getMoveItems() 대신)
-    List<MoveItems> moveItems = moveItemsRepository.findByEstimateNo(estimateNo);
-
-    // 2. 각 item의 item_totalPrice 합산
-    int itemTotalPrice = moveItems.stream()
-        .mapToInt(item -> item.getItem_totalPrice() != null ? item.getItem_totalPrice() : 0)
-        .sum();
-
-    // 최종 견적 총금액 저장
-    estimate.setTotalPrice(itemTotalPrice + totalExtraCharge);
 
     estimate.setOwnerMessage(request.getOwnerMessage());
     estimate.setStoreId(storeId);
     estimate.setStoreName(store.getName());
     estimate.setStatus(EstimateStatus.ACCEPTED);
+    estimate.setTruckCount(request.getTruckCount());
     estimateRepository.save(estimate);
 
-    log.info("[EstimateDetailUpdateService] 사장님 입력 저장 완료 - estimateNo: {}, totalExtraCharge: {}, message: {}",
-        estimateNo, totalExtraCharge, request.getOwnerMessage());
+    log.info("[EstimateDetailUpdateService] 사장님 입력 저장 완료 - estimateNo: {} message: {}",
+        estimateNo, request.getOwnerMessage());
+  }
+
+  @Transactional
+  public CalculateOwnerInputResponse calculateAndSaveFinalTotals(Long storeId, Long estimateNo) {
+    // 1) EstimateCalculation 조회 또는 새로 생성
+    EstimateCalculation estimateCalculation = estimateCalculationRepository.findByEstimateNo(
+            estimateNo)
+        .orElseGet(() -> {
+          EstimateCalculation e = new EstimateCalculation();
+          e.setEstimateNo(estimateNo);
+          e.setStoreId(storeId);
+          return e;
+        });
+
+    // 2) DB에서 items_total_price 꺼내기
+    int itemsTotal = estimateCalculation.getItemsTotalPrice();
+
+    // 3) DB에서 추가금 합산
+    int extraTotal = estimateExtraChargeRepository.findByEstimateNo(estimateNo).stream()
+        .mapToInt(EstimateExtraCharge::getAmount)
+        .sum();
+
+    Estimate estimate = estimateRepository.findById(estimateNo)
+        .orElseThrow(() -> new IllegalArgumentException("해당 견적이 없습니다."));
+
+    int truckCount = estimate.getTruckCount();
+
+    StorePriceSetting setting = storePriceSettingRepository.findByStoreId(storeId)
+        .orElseThrow(() -> new IllegalArgumentException("사장님 가격 설정 정보가 없습니다."));
+
+    int perTruckCharge = setting.getPerTruckCharge();
+
+    int truckCountCharge = truckCount * perTruckCharge;
+
+    // 4) 계산된 값 반영
+    estimateCalculation.setExtraChargesTotal(extraTotal);
+    estimateCalculation.setTruck_charge(truckCountCharge);
+    estimateCalculation.setFinalTotalPrice(itemsTotal + extraTotal + truckCountCharge);
+
+    // 5) 저장
+    estimateCalculationRepository.save(estimateCalculation);
+
+    log.info("[calculateAndSaveFinalTotals] estNo={}, itemsTotal={}, extraTotal={}, finalTotal={}",
+        estimateNo, itemsTotal, extraTotal, itemsTotal + extraTotal);
+
+    // 6) DTO로 반환
+    return CalculateOwnerInputResponse.builder()
+        .itemTotal(itemsTotal)
+        .extraTotal(extraTotal)
+        .truck_charge(truckCountCharge)
+        .finalTotal(itemsTotal + extraTotal + truckCountCharge)
+        .build();
   }
 
   private void saveExtraCharge(Long estimateNo, Long storeId, String reason, int amount) {


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) ✨ [FEAT/#1] 로그인 페이지 UI 구현 -->
✨ [FEAT/#17] EstimateCalculation 엔티티 생성 및 계산/저장 책임 분리

## 🚀 관련 이슈
- closed #17 

## 📝 작업 내용
- EstimateCalculation 엔티티 생성
  - itemTotalPrice, finalTotalPrice 필드 이동
- 계산 로직과 저장 로직의 책임을 분리하여 구조 개선
  - 계산은 서비스 로직에서 수행
  - 저장은 별도 저장 책임으로 수행
- 견적 확정 시 계산 결과를 EstimateCalculation에 저장

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
